### PR TITLE
feat(install): replace updtr by npm-check

### DIFF
--- a/install/npm.sh
+++ b/install/npm.sh
@@ -25,7 +25,7 @@ packages=(
   flow-bin
   greenkeeper
   mocha
-  updtr
+  npm-check
 )
 
 npm install -g "${packages[@]}"


### PR DESCRIPTION
Mainly because npm-check support globals interactive npm update
